### PR TITLE
Implement global adaptive time step using RMS of individual dt_i values

### DIFF
--- a/src/evolution.c
+++ b/src/evolution.c
@@ -17,22 +17,21 @@ double Min(double a, double b){
 }
 
 double get_dt(Particle* P, int npart, double dt_max, double eta, double epsilon) {
-    double sum_dt2 = 0.0;
+    double sum_a2 = 0.0;
 
     for (int i = 0; i < npart; i++) {
-        // acceleration a = f / m
-        double a_mag = 0.0;
+        // Compute |a|^2 = |f/m|^2
+        double a2 = 0.0;
         for (int j = 0; j < 3; j++) {
             double a_j = P[i].f[j] / P[i].m;
-            a_mag += a_j * a_j;
+            a2 += a_j * a_j;
         }
-        a_mag = sqrt(a_mag);
-        double dti = sqrt(2.0 * eta * epsilon / a_mag);
-        sum_dt2 += dti * dti;
+        sum_a2 += a2;
     }
 
-    double rms_dt = sqrt(sum_dt2 / npart);
-    return (rms_dt < dt_max) ? rms_dt : dt_max;
+    double rms_a = sqrt(sum_a2 / npart);
+    double dt = sqrt(2.0 * eta * epsilon / rms_a);
+    return (dt < dt_max) ? dt : dt_max;
 }
 
 double Evolution(Particle* P, int npart, double dt_max, double eta, double epsilon) {

--- a/src/evolution.c
+++ b/src/evolution.c
@@ -16,7 +16,7 @@ double Min(double a, double b){
     return b;
 }
 
-double get_dt(Particle* P, int npart, double dt_max, double eta, double epsilon) {
+double compute_dt(Particle* P, int npart, double dt_max, double eta, double epsilon) {
     double sum_a2 = 0.0;
 
     for (int i = 0; i < npart; i++) {
@@ -35,7 +35,7 @@ double get_dt(Particle* P, int npart, double dt_max, double eta, double epsilon)
 }
 
 double Evolution(Particle* P, int npart, double dt_max, double eta, double epsilon) {
-    double dt = get_dt(P, npart, dt_max, eta, epsilon);
+    double dt = compute_dt(P, npart, dt_max, eta, epsilon);
     // (a) Drift by 0.5*dt for all particles   
     for (int i = 0; i < npart; i++) {
         for (int j = 0; j < DIM; j++) {

--- a/src/evolution.h
+++ b/src/evolution.h
@@ -3,6 +3,7 @@
 
 #include "particle.h"
 
+double compute_dt(Particle* P, int npart, double dt_max, double eta, double epsilon);
 double Evolution(Particle* P, int npart, double dt_max, double eta, double epsilon);
 double Max(double a, double b);
 double Min(double a, double b);

--- a/src/evolution.h
+++ b/src/evolution.h
@@ -3,7 +3,7 @@
 
 #include "particle.h"
 
-void Evolution(Particle* P, int npart, double dt);
+double Evolution(Particle* P, int npart, double dt_max, double eta, double epsilon);
 double Max(double a, double b);
 double Min(double a, double b);
 

--- a/src/force.c
+++ b/src/force.c
@@ -32,8 +32,8 @@ void two_particle_force(Particle* a, Particle* b, double* force, double epsilon)
 }
 
 // Update p.f[:] by gravitational force (brute force)
-void total_force(Particle* p, int npart){
-    double epsilon = get_double("BasicSetting.epsilon", 1e-10);
+void total_force(Particle* p, int npart, double epsilon){
+    // double epsilon = get_double("BasicSetting.epsilon", 1e-10);
     for (int i = 0; i < npart; i++){
         for (int k = 0; k < DIM; k++) {
             p[i].f[k] = 0.0;

--- a/src/force.h
+++ b/src/force.h
@@ -5,6 +5,6 @@
 
 int Force(int a);
 void two_particle_force(Particle* a, Particle* b, double* force, double epsilon);
-void total_force(Particle* p, int npart);
+void total_force(Particle* p, int npart, double epsilon);
  
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -19,8 +19,10 @@ int main(){
     // Main Calculation
     double T_TOT = get_double("BasicSetting.T_TOT", 0.0);
     double DT = get_double("BasicSetting.DT", 0.1);
+    double ETA = get_double("BasicSetting.ETA", 1.0);
+    double EPSILON = get_double("BasicSetting.EPSILON", 1e-12);
     double t = 0.0;
-    int STEP_PER_OUT = get_int("BasicSetting.STEP_PER_OUT", 10);
+    int STEP_PER_OUT = get_int("BasicSetting.STEP_PER_OUT", 10000);
     int step = 0;
     while(t < T_TOT){
         struct timeval t0, t1;
@@ -28,9 +30,9 @@ int main(){
         step++;
 
         // Update P[:].x & P[:].v & P[:].f
-        double dt = Min(DT, T_TOT - t);
-        Evolution(P, npart, dt);
-        t = Min(t + DT + 1e-15, T_TOT);
+        double dt = Evolution(P, npart, Min(DT, T_TOT - t), ETA, EPSILON);
+        printf("time step dt: %f\n", dt);
+        t = Min(t + dt + 1e-15, T_TOT);
 
         gettimeofday(&t1, 0);
         // Print info

--- a/testcase/test_plummer/Input_Parameter.ini
+++ b/testcase/test_plummer/Input_Parameter.ini
@@ -6,6 +6,8 @@ PARTICLE_FILE = Initial.dat  # filename of particle file (default: Initial.dat)
 N_TOT = 128                  # Number of base-level cell on each side
 T_TOT = 5.1                  # total evolution time
 DT = 0.2                     # maximal time interval
+ETA = 1000000.0                    # parameter that controls the accuracy and stability of the timestep in simulations
+EPSILON = 1e-12              # softening length used to prevent singularities and numerical instabilities in particle interactions
 
 [FundamentalConst]
 G   = 1                      # Newton's gravity constant

--- a/testcase/test_random/Input_Parameter.ini
+++ b/testcase/test_random/Input_Parameter.ini
@@ -5,6 +5,8 @@ METHOD = 2                   # Method 1:brute_force
 PARTICLE_FILE = Initial.dat  # filename of particle file (default: Initial.dat)
 T_TOT = 0.1                  # total evolution time
 DT = 0.01                    # maximal time interval
+ETA = 1.0                    # parameter that controls the accuracy and stability of the timestep in simulations
+EPSILON = 1e-12              # softening length used to prevent singularities and numerical instabilities in particle interactions
 STEP_PER_OUT = 3             # Output 00xxx.dat in every STEP_PER_OUT steps
 
 [Tree]


### PR DESCRIPTION
Each particle computes its own suggested time step dt_i = sqrt(2 * eta * epsilon / |a|). The global step dt is then set to the minimum of DT which is read from Input_Parameter and the RMS of all dt_i.